### PR TITLE
add: READMEにプロジェクトの説明を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # TodoList
+
+1. 背景
+プロジェクトの背景、目的、期待される効果、成果を説明します
+- 背景：技術力向上
+- やること：以下機能を搭載したTODOリストを作成する
+  - 機能
+    - CRUD操作
+    - ステータス管理
+    - 通知機能
+      - UPDATEされたら会員登録したメールアドレスに通知が届く
+    - 会員登録
+- 技術構成
+  - フロントエンド：Vue（Nuxt.jsというフレームワーク）
+  - バックエンド：Go（GoのEchoというフレームワーク）
+    - DBとの接続：sqlc
+  - DB：PostgreSQL
+  - コンテナ：Docker
+  - デプロイ
+    - フロントエンド：Vercel
+    - バックエンド：Google Cloud Platform
+  - IaC(Infrastructure as Code)
+    - Terraform：GCPをコードで設定できる
+  - プロジェクト管理
+    - Git、Github
+  - オプション
+    - CI
+      - Github Action
+      - Circle CI


### PR DESCRIPTION
その名の通り、今回のTODOリストを作成する背景や目的を追加した。
pushできるかのテストも兼ねてます。